### PR TITLE
🧑‍💻: cloc によるコード行数カウント対象外ファイルの追加

### DIFF
--- a/.clocignore
+++ b/.clocignore
@@ -1,0 +1,12 @@
+########################################################
+# cloc によるコード行数カウントの除外path
+# 使い方
+# cloc [path] --exclude-list-file=.clocignore --vcs=git
+# ※ "--vcs=git" オプションを使うことで .gitignore が考慮されるので、gitignoreしているものは書く必要はない
+
+## 参考: https://github.com/AlDanial/cloc/issues/49
+########################################################
+
+
+# 100%見ない訳では無いが、これを含めると大きくなりすぎる
+frontend/package-lock.json


### PR DESCRIPTION
## 概要

- [x] `.clocignore`の追加
  - 設定は一旦`frontend`分のみ

## 実行方法

```bash
cloc frontend --exclude-list-file=.clocignore --vcs=git
```